### PR TITLE
ci: Add label to CI pull request

### DIFF
--- a/.github/workflows/render.yml
+++ b/.github/workflows/render.yml
@@ -71,4 +71,4 @@ jobs:
       - name: Merge Pull Request
         shell: bash
         run: |
-          gh pr merge --auto --squash --delete-branch
+          gh pr merge --auto --squash --delete-branch --label "Type: CI/CD :robot:"


### PR DESCRIPTION
This pull request adds a label "Type: CI/CD :robot:" to the automated CI pull requests. This label will help in categorizing and identifying CI-related pull requests easily.